### PR TITLE
Add restaurant form and map list view

### DIFF
--- a/src/AddRestaurantForm.js
+++ b/src/AddRestaurantForm.js
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+function AddRestaurantForm({ onAdd }) {
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [latitude, setLatitude] = useState('');
+  const [longitude, setLongitude] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onAdd({
+      name,
+      address: address || null,
+      latitude: latitude ? parseFloat(latitude) : null,
+      longitude: longitude ? parseFloat(longitude) : null,
+    });
+    setName('');
+    setAddress('');
+    setLatitude('');
+    setLongitude('');
+  };
+
+  return (
+    <form className="AddForm" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <input
+        type="text"
+        placeholder="Address"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+      />
+      <input
+        type="number"
+        step="any"
+        placeholder="Latitude"
+        value={latitude}
+        onChange={(e) => setLatitude(e.target.value)}
+      />
+      <input
+        type="number"
+        step="any"
+        placeholder="Longitude"
+        value={longitude}
+        onChange={(e) => setLongitude(e.target.value)}
+      />
+      <button type="submit">Add</button>
+    </form>
+  );
+}
+
+export default AddRestaurantForm;

--- a/src/App.css
+++ b/src/App.css
@@ -52,3 +52,31 @@
 .Map-wrapper {
   height: 400px;
 }
+
+.AddForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: 1rem auto;
+}
+
+.AddForm input,
+.AddForm button {
+  padding: 0.5rem;
+}
+
+.MapWithList {
+  display: flex;
+}
+
+.SideList {
+  width: 200px;
+  overflow-y: auto;
+  margin-right: 1rem;
+  text-align: left;
+}
+
+.Map-area {
+  flex: 1;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,23 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
 import MapView from './MapView';
+import AddRestaurantForm from './AddRestaurantForm';
+import mapData from './mapData.json';
 
 function App() {
   const [tab, setTab] = useState('home');
+  const [data, setData] = useState(() => {
+    const stored = localStorage.getItem('mapData');
+    return stored ? JSON.parse(stored) : mapData;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('mapData', JSON.stringify(data));
+  }, [data]);
+
+  const handleAdd = (item) => {
+    setData([...data, { ...item, notes: '', visited: false, rating: null, category: '' }]);
+  };
 
   return (
     <div className="App">
@@ -22,33 +36,13 @@ function App() {
         </button>
       </nav>
       {tab === 'home' && (
-        <header className="App-header">
-          <img
-            src={process.env.PUBLIC_URL + '/Octocat.png'}
-            className="App-logo"
-            alt="logo"
-          />
-          <p>
-            GitHub Codespaces <span className="heart">♥️</span> React
-          </p>
-          <p className="small">
-            Edit <code>src/App.js</code> and save to reload.
-          </p>
-          <p>
-            <a
-              className="App-link"
-              href="https://reactjs.org"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Learn React
-            </a>
-          </p>
-        </header>
+        <div className="Form-wrapper">
+          <AddRestaurantForm onAdd={handleAdd} />
+        </div>
       )}
       {tab === 'map' && (
         <div className="Map-wrapper">
-          <MapView />
+          <MapView data={data} />
         </div>
       )}
     </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders add button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const addButton = screen.getByRole('button', { name: /add/i });
+  expect(addButton).toBeInTheDocument();
 });

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -1,7 +1,7 @@
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
-import mapData from './mapData.json';
+// Map data is provided by parent via props
 
 // Fix leaflet's default icon paths
 delete L.Icon.Default.prototype._getIconUrl;
@@ -14,8 +14,8 @@ L.Icon.Default.mergeOptions({
     'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
 });
 
-function MapView() {
-  const markers = mapData.filter(
+function MapView({ data }) {
+  const markers = data.filter(
     (m) => m.latitude !== null && m.longitude !== null
   );
 
@@ -23,11 +23,20 @@ function MapView() {
     markers.length > 0 ? [markers[0].latitude, markers[0].longitude] : [0, 0];
 
   return (
-    <MapContainer
-      center={center}
-      zoom={11}
-      style={{ height: '400px', width: '100%' }}
-    >
+    <div className="MapWithList">
+      <div className="SideList">
+        <ul>
+          {data.map((item, idx) => (
+            <li key={idx}>{item.name}</li>
+          ))}
+        </ul>
+      </div>
+      <MapContainer
+        className="Map-area"
+        center={center}
+        zoom={11}
+        style={{ height: '400px', width: '100%' }}
+      >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution="&copy; OpenStreetMap contributors"
@@ -41,7 +50,8 @@ function MapView() {
           </Popup>
         </Marker>
       ))}
-    </MapContainer>
+      </MapContainer>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the Home tab content with a restaurant entry form
- store restaurant data in localStorage and pass into MapView
- display list of all places alongside the map
- adjust styling for form and side list
- update tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f80c2818c83248e83e0f2a877e6d0