### PR TITLE
Add interactive list with map popups and detail modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,6 +77,19 @@
   text-align: left;
 }
 
+.SideList li {
+  cursor: pointer;
+  padding: 0.25rem 0;
+}
+
+.SideList li:hover {
+  background: #f0f0f0;
+}
+
+.arrow {
+  margin-right: 0.25rem;
+}
+
 .Map-area {
   flex: 1;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,11 @@ function App() {
       )}
       {tab === 'map' && (
         <div className="Map-wrapper">
-          <MapView data={data} />
+          <MapView data={data} onUpdate={(idx, updates) =>
+            setData((d) =>
+              d.map((item, i) => (i === idx ? { ...item, ...updates } : item))
+            )
+          } />
         </div>
       )}
     </div>

--- a/src/DetailModal.css
+++ b/src/DetailModal.css
@@ -1,0 +1,39 @@
+.Modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.Modal {
+  background: white;
+  padding: 1rem;
+  max-width: 300px;
+  width: 100%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.Modal label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.Modal input[type='text'] {
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
+.Modal .actions {
+  margin-top: 1rem;
+  text-align: right;
+}
+
+.Modal button {
+  margin-left: 0.5rem;
+}

--- a/src/DetailModal.js
+++ b/src/DetailModal.js
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import './DetailModal.css';
+
+function DetailModal({ item, onClose, onSave }) {
+  const [name, setName] = useState(item.name);
+  const [address, setAddress] = useState(item.address || '');
+  const [visited, setVisited] = useState(item.visited || false);
+
+  const handleSave = () => {
+    onSave({ name, address, visited });
+  };
+
+  return (
+    <div className="Modal-overlay">
+      <div className="Modal">
+        <h3>Edit Place</h3>
+        <label>
+          Name
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label>
+          Address
+          <input value={address} onChange={(e) => setAddress(e.target.value)} />
+        </label>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={visited}
+            onChange={(e) => setVisited(e.target.checked)}
+          />
+          Visited
+        </label>
+        <div className="actions">
+          <button onClick={handleSave}>Save</button>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DetailModal;

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -1,6 +1,8 @@
+import { useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
+import DetailModal from './DetailModal';
 // Map data is provided by parent via props
 
 // Fix leaflet's default icon paths
@@ -14,20 +16,39 @@ L.Icon.Default.mergeOptions({
     'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
 });
 
-function MapView({ data }) {
-  const markers = data.filter(
-    (m) => m.latitude !== null && m.longitude !== null
-  );
+function MapView({ data, onUpdate }) {
+  const mapRef = useRef();
+  const markerRefs = useRef({});
+  const [modalIndex, setModalIndex] = useState(null);
+
+  const markers = data
+    .map((m, idx) =>
+      m.latitude !== null && m.longitude !== null ? { ...m, idx } : null
+    )
+    .filter(Boolean);
 
   const center =
     markers.length > 0 ? [markers[0].latitude, markers[0].longitude] : [0, 0];
+
+  const handleItemClick = (idx) => {
+    const item = data[idx];
+    if (item.latitude !== null && item.longitude !== null && mapRef.current) {
+      mapRef.current.flyTo([item.latitude, item.longitude], 13);
+      const ref = markerRefs.current[idx];
+      if (ref) {
+        ref.openPopup();
+      }
+    }
+  };
 
   return (
     <div className="MapWithList">
       <div className="SideList">
         <ul>
           {data.map((item, idx) => (
-            <li key={idx}>{item.name}</li>
+            <li key={idx} onClick={() => handleItemClick(idx)}>
+              <span className="arrow">\u279C</span> {item.name}
+            </li>
           ))}
         </ul>
       </div>
@@ -41,8 +62,17 @@ function MapView({ data }) {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution="&copy; OpenStreetMap contributors"
       />
-      {markers.map((marker, idx) => (
-        <Marker position={[marker.latitude, marker.longitude]} key={idx}>
+      {markers.map((marker) => (
+        <Marker
+          position={[marker.latitude, marker.longitude]}
+          key={marker.idx}
+          ref={(ref) => {
+            if (ref) markerRefs.current[marker.idx] = ref;
+          }}
+          eventHandlers={{
+            click: () => setModalIndex(marker.idx),
+          }}
+        >
           <Popup>
             <strong>{marker.name}</strong>
             {marker.address && <br />}
@@ -51,6 +81,16 @@ function MapView({ data }) {
         </Marker>
       ))}
       </MapContainer>
+      {modalIndex !== null && (
+        <DetailModal
+          item={data[modalIndex]}
+          onClose={() => setModalIndex(null)}
+          onSave={(updates) => {
+            onUpdate && onUpdate(modalIndex, updates);
+            setModalIndex(null);
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enable clicking list items to fly to markers
- show arrow indicator next to list entries
- open detail modal when clicking markers
- allow editing of place details including visited flag

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f847b3bd08324be45bf9a46e84282