### PR TITLE
Add dark mode theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,18 +8,18 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: var(--header-bg);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
+  color: var(--text-color);
 }
 
 .App-link {
-  color: #61dafb;
+  color: var(--active-tab-bg);
 }
 
 .heart {
@@ -30,23 +30,29 @@
   font-size: 0.75rem;
 }
 
+
 .Tabs {
   display: flex;
-  background: #282c34;
+  background: var(--header-bg);
 }
 
 .Tabs button {
   flex: 1;
   padding: 0.5rem;
   border: none;
-  background: #444;
-  color: white;
+  background: var(--button-bg);
+  color: var(--button-text);
   cursor: pointer;
 }
 
+.Tabs button.toggle {
+  flex: 0;
+  padding: 0 1rem;
+}
+
 .Tabs button.active {
-  background: #61dafb;
-  color: #282c34;
+  background: var(--active-tab-bg);
+  color: var(--active-tab-color);
 }
 
 .Map-wrapper {
@@ -64,6 +70,16 @@
 .AddForm input,
 .AddForm button {
   padding: 0.5rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--button-bg);
+}
+
+.AddForm button {
+  background: var(--button-bg);
+  color: var(--button-text);
+  border: none;
+  cursor: pointer;
 }
 
 .MapWithList {
@@ -83,7 +99,7 @@
 }
 
 .SideList li:hover {
-  background: #f0f0f0;
+  background: var(--hover-bg);
 }
 
 .arrow {

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import mapData from './mapData.json';
 
 function App() {
   const [tab, setTab] = useState('home');
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const [darkMode, setDarkMode] = useState(prefersDark);
   const [data, setData] = useState(() => {
     const stored = localStorage.getItem('mapData');
     return stored ? JSON.parse(stored) : mapData;
@@ -14,6 +16,10 @@ function App() {
   useEffect(() => {
     localStorage.setItem('mapData', JSON.stringify(data));
   }, [data]);
+
+  useEffect(() => {
+    document.body.dataset.theme = darkMode ? 'dark' : 'light';
+  }, [darkMode]);
 
   const handleAdd = (item) => {
     setData([...data, { ...item, notes: '', visited: false, rating: null, category: '' }]);
@@ -33,6 +39,12 @@ function App() {
           onClick={() => setTab('map')}
         >
           Map
+        </button>
+        <button
+          className="toggle"
+          onClick={() => setDarkMode(!darkMode)}
+        >
+          {darkMode ? 'Light' : 'Dark'}
         </button>
       </nav>
       {tab === 'home' && (

--- a/src/DetailModal.css
+++ b/src/DetailModal.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--modal-overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -12,7 +12,8 @@
 }
 
 .Modal {
-  background: white;
+  background: var(--modal-bg);
+  color: var(--text-color);
   padding: 1rem;
   max-width: 300px;
   width: 100%;
@@ -27,6 +28,9 @@
 .Modal input[type='text'] {
   width: 100%;
   margin-top: 0.25rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--button-bg);
 }
 
 .Modal .actions {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,30 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --header-bg: #f5f5f5;
+  --button-bg: #444444;
+  --button-text: #ffffff;
+  --active-tab-bg: #06c167;
+  --active-tab-color: #ffffff;
+  --hover-bg: #f0f0f0;
+  --modal-bg: #ffffff;
+  --modal-overlay-bg: rgba(0, 0, 0, 0.5);
+  --accent-color: #06c167;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #ffffff;
+  --header-bg: #1f1f1f;
+  --button-bg: #333333;
+  --button-text: #ffffff;
+  --active-tab-bg: #06c167;
+  --active-tab-color: #ffffff;
+  --hover-bg: #333333;
+  --modal-bg: #1f1f1f;
+  --modal-overlay-bg: rgba(0, 0, 0, 0.8);
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,6 +32,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--bg-color);
+  color: var(--text-color);
+  transition: background 0.3s, color 0.3s;
 }
 
 code {


### PR DESCRIPTION
## Summary
- add CSS variables and dark theme palette
- convert app styles to use variables
- style modal with theme variables
- toggle dark mode from navbar

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683f8bdc82e0832485b0feeea2e72fef