### PR TITLE
Add dark mode tile layer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,11 +54,15 @@ function App() {
       )}
       {tab === 'map' && (
         <div className="Map-wrapper">
-          <MapView data={data} onUpdate={(idx, updates) =>
-            setData((d) =>
-              d.map((item, i) => (i === idx ? { ...item, ...updates } : item))
-            )
-          } />
+          <MapView
+            data={data}
+            darkMode={darkMode}
+            onUpdate={(idx, updates) =>
+              setData((d) =>
+                d.map((item, i) => (i === idx ? { ...item, ...updates } : item))
+              )
+            }
+          />
         </div>
       )}
     </div>

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -16,7 +16,7 @@ L.Icon.Default.mergeOptions({
     'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
 });
 
-function MapView({ data, onUpdate }) {
+function MapView({ data, onUpdate, darkMode = false }) {
   const mapRef = useRef();
   const markerRefs = useRef({});
   const [modalIndex, setModalIndex] = useState(null);
@@ -72,7 +72,11 @@ function MapView({ data, onUpdate }) {
         style={{ height: '100%', width: '100%' }}
       >
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url={
+          darkMode
+            ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+            : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        }
         attribution="&copy; OpenStreetMap contributors"
       />
       {markers.map((marker) => (


### PR DESCRIPTION
## Summary
- toggle dark style on the map using a new `darkMode` prop
- pass `darkMode` from `App` to `MapView`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68403d6ee6e88324840db680acc30b26