### PR TITLE
Improve map responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,7 +56,8 @@
 }
 
 .Map-wrapper {
-  height: 400px;
+  height: 60vh;
+  min-height: 350px;
 }
 
 .AddForm {
@@ -85,6 +86,7 @@
 .MapWithList {
   display: flex;
   height: 100%;
+  min-height: 60vh;
 }
 
 .SideList {
@@ -150,9 +152,12 @@
     width: 100%;
     margin-right: 0;
     margin-bottom: 1rem;
+    max-height: 40vh;
+    overflow-y: auto;
   }
 
   .Map-wrapper {
-    height: 300px;
+    height: 75vh;
+    min-height: 300px;
   }
 }

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -86,7 +86,7 @@ function MapView({ data, onUpdate, darkMode = false }) {
         className="Map-area"
         center={center}
         zoom={11}
-        style={{ height: '400px', width: '100%' }}
+        style={{ height: '100%', width: '100%' }}
         ref={mapRef}
       >
       <TileLayer


### PR DESCRIPTION
## Summary
- ensure the map is visible on small screens by giving the list a max height
- allow more vertical space for the map in phone portrait mode

## Testing
- `CI=true npm test -- src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68404569d6d88324a9ab367512b63aab