### PR TITLE
Enhance app styling and add loading screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,20 +34,24 @@
 .Tabs {
   display: flex;
   background: var(--header-bg);
+  border-bottom: 1px solid var(--hover-bg);
 }
 
 .Tabs button {
   flex: 1;
-  padding: 0.5rem;
+  padding: 0.5rem 0.75rem;
   border: none;
   background: var(--button-bg);
   color: var(--button-text);
   cursor: pointer;
+  border-radius: 0.25rem 0.25rem 0 0;
+  transition: background 0.2s;
 }
 
 .Tabs button.toggle {
   flex: 0;
   padding: 0 1rem;
+  border-radius: 0;
 }
 
 .Tabs button.active {
@@ -73,7 +77,8 @@
   padding: 0.5rem;
   background: var(--bg-color);
   color: var(--text-color);
-  border: 1px solid var(--button-bg);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.25rem;
 }
 
 .AddForm button {
@@ -81,6 +86,11 @@
   color: var(--button-text);
   border: none;
   cursor: pointer;
+  transition: background 0.2s;
+}
+
+.AddForm button:hover {
+  background: var(--active-tab-bg);
 }
 
 .MapWithList {
@@ -94,6 +104,7 @@
   overflow-y: auto;
   margin-right: 1rem;
   text-align: left;
+  padding: 0.5rem 0;
 }
 
 .SideList .search-input {
@@ -104,6 +115,7 @@
   background: var(--bg-color);
   color: var(--text-color);
   border: 1px solid var(--hover-bg);
+  border-radius: 0.25rem;
 }
 
 .place-card {
@@ -116,10 +128,13 @@
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
+  border-radius: 0.25rem;
+  transition: background 0.2s;
 }
 
 .place-card:hover {
   background: var(--hover-bg);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .card-info .title {

--- a/src/App.js
+++ b/src/App.js
@@ -2,16 +2,24 @@ import { useState, useEffect } from 'react';
 import './App.css';
 import MapView from './MapView';
 import AddRestaurantForm from './AddRestaurantForm';
+import LoadingScreen from './LoadingScreen';
 import mapData from './mapData.json';
 
 function App() {
   const [tab, setTab] = useState('home');
-  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const [loading, setLoading] = useState(true);
+  const prefersDark =
+    window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const [darkMode, setDarkMode] = useState(prefersDark);
   const [data, setData] = useState(() => {
     const stored = localStorage.getItem('mapData');
     return stored ? JSON.parse(stored) : mapData;
   });
+
+  useEffect(() => {
+    const id = setTimeout(() => setLoading(false), 1000);
+    return () => clearTimeout(id);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('mapData', JSON.stringify(data));
@@ -27,6 +35,7 @@ function App() {
 
   return (
     <div className="App">
+      {loading && <LoadingScreen />}
       <nav className="Tabs">
         <button
           className={tab === 'home' ? 'active' : ''}

--- a/src/DetailModal.css
+++ b/src/DetailModal.css
@@ -18,6 +18,7 @@
   max-width: 300px;
   width: 100%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 0.5rem;
 }
 
 .Modal label {
@@ -30,7 +31,8 @@
   margin-top: 0.25rem;
   background: var(--bg-color);
   color: var(--text-color);
-  border: 1px solid var(--button-bg);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.25rem;
 }
 
 .Modal .actions {
@@ -40,4 +42,6 @@
 
 .Modal button {
   margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
 }

--- a/src/LoadingScreen.css
+++ b/src/LoadingScreen.css
@@ -1,0 +1,27 @@
+.LoadingOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--modal-overlay-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.Spinner {
+  width: 60px;
+  height: 60px;
+  border: 6px solid var(--bg-color);
+  border-top-color: var(--accent-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/LoadingScreen.js
+++ b/src/LoadingScreen.js
@@ -1,0 +1,11 @@
+import './LoadingScreen.css';
+
+function LoadingScreen() {
+  return (
+    <div className="LoadingOverlay">
+      <div className="Spinner" />
+    </div>
+  );
+}
+
+export default LoadingScreen;

--- a/src/index.css
+++ b/src/index.css
@@ -1,34 +1,37 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+
 :root {
-  --bg-color: #ffffff;
-  --text-color: #000000;
-  --header-bg: #f5f5f5;
-  --button-bg: #444444;
+  --bg-color: #f8f9fa;
+  --text-color: #111827;
+  --header-bg: #ffffff;
+  --button-bg: #4f46e5;
   --button-text: #ffffff;
-  --active-tab-bg: #06c167;
+  --active-tab-bg: #4f46e5;
   --active-tab-color: #ffffff;
-  --hover-bg: #f0f0f0;
+  --hover-bg: #f1f5f9;
   --modal-bg: #ffffff;
   --modal-overlay-bg: rgba(0, 0, 0, 0.5);
-  --accent-color: #06c167;
+  --accent-color: #4f46e5;
 }
 
 [data-theme='dark'] {
-  --bg-color: #121212;
-  --text-color: #ffffff;
-  --header-bg: #1f1f1f;
-  --button-bg: #333333;
+  --bg-color: #0f172a;
+  --text-color: #f8fafc;
+  --header-bg: #1e293b;
+  --button-bg: #4f46e5;
   --button-text: #ffffff;
-  --active-tab-bg: #06c167;
+  --active-tab-bg: #4f46e5;
   --active-tab-color: #ffffff;
-  --hover-bg: #333333;
-  --modal-bg: #1f1f1f;
+  --hover-bg: #334155;
+  --modal-bg: #1e293b;
   --modal-overlay-bg: rgba(0, 0, 0, 0.8);
+  --accent-color: #818cf8;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
- overhaul light/dark theme with new color palette and Inter font
- polish component styles with rounded elements and smoother transitions
- add loading overlay with spinner on initial load

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684065d5ed8c8324bd686aa025e75144