### PR TITLE
Improve mobile layout and dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -35,6 +35,8 @@
   display: flex;
   background: var(--header-bg);
   border-bottom: 1px solid var(--hover-bg);
+  height: var(--nav-height);
+  align-items: center;
 }
 
 .Tabs button {
@@ -46,6 +48,7 @@
   cursor: pointer;
   border-radius: 0.25rem 0.25rem 0 0;
   transition: background 0.2s;
+  height: 100%;
 }
 
 .Tabs button.toggle {
@@ -60,7 +63,7 @@
 }
 
 .Map-wrapper {
-  height: 60vh;
+  height: calc(100vh - var(--nav-height));
   min-height: 350px;
 }
 
@@ -159,6 +162,19 @@
 }
 
 @media (max-width: 600px) {
+  body {
+    padding-bottom: var(--nav-height);
+  }
+
+  .Tabs {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-top: 1px solid var(--hover-bg);
+    border-bottom: none;
+  }
+
   .MapWithList {
     flex-direction: column;
   }
@@ -172,7 +188,7 @@
   }
 
   .Map-wrapper {
-    height: 75vh;
+    height: calc(100vh - var(--nav-height));
     min-height: 300px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,20 +12,21 @@
   --modal-bg: #ffffff;
   --modal-overlay-bg: rgba(0, 0, 0, 0.5);
   --accent-color: #4f46e5;
+  --nav-height: 3rem;
 }
 
 [data-theme='dark'] {
-  --bg-color: #0f172a;
+  --bg-color: #000000;
   --text-color: #f8fafc;
-  --header-bg: #1e293b;
-  --button-bg: #4f46e5;
+  --header-bg: #000000;
+  --button-bg: #000000;
   --button-text: #ffffff;
-  --active-tab-bg: #4f46e5;
+  --active-tab-bg: #000000;
   --active-tab-color: #ffffff;
-  --hover-bg: #334155;
-  --modal-bg: #1e293b;
+  --hover-bg: #1a1a1a;
+  --modal-bg: #000000;
   --modal-overlay-bg: rgba(0, 0, 0, 0.8);
-  --accent-color: #818cf8;
+  --accent-color: #ffffff;
 }
 
 body {


### PR DESCRIPTION
## Summary
- make dark theme use pitch black with white accents
- ensure map page fills the screen
- create a fixed bottom tab bar on small screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406dcfcec88324b55c9d175d36f2f0