### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,13 +30,45 @@
   font-size: 0.75rem;
 }
 
-
 .Tabs {
   display: flex;
   background: var(--header-bg);
   border-bottom: 1px solid var(--hover-bg);
   height: var(--nav-height);
   align-items: center;
+  justify-content: space-around;
+  position: relative;
+  z-index: 10;
+}
+
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  padding: 0 0.75rem;
+  cursor: pointer;
+  color: var(--text-color);
+  height: 100%;
+}
+
+.Menu {
+  display: flex;
+  flex: 1;
+  height: 100%;
+}
+
+.Menu button {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.Menu .icon {
+  font-size: 1.2rem;
 }
 
 .Tabs button {
@@ -49,6 +81,11 @@
   border-radius: 0.25rem 0.25rem 0 0;
   transition: background 0.2s;
   height: 100%;
+}
+
+.Tabs .hamburger {
+  background: none;
+  color: var(--text-color);
 }
 
 .Tabs button.toggle {
@@ -175,6 +212,10 @@
     border-bottom: none;
   }
 
+  .Menu {
+    justify-content: space-around;
+  }
+
   .MapWithList {
     flex-direction: column;
   }
@@ -190,5 +231,29 @@
   .Map-wrapper {
     height: calc(100vh - var(--nav-height));
     min-height: 300px;
+  }
+}
+
+@media (min-width: 601px) {
+  .hamburger {
+    display: block;
+  }
+
+  .Menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 200px;
+    flex-direction: column;
+    background: var(--header-bg);
+    padding-top: var(--nav-height);
+    transform: translateX(-100%);
+    transition: transform 0.3s;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+  }
+
+  .Menu.open {
+    transform: translateX(0);
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,20 @@
-import { useState, useEffect } from 'react';
-import './App.css';
-import MapView from './MapView';
-import AddRestaurantForm from './AddRestaurantForm';
-import LoadingScreen from './LoadingScreen';
-import mapData from './mapData.json';
+import { useState, useEffect } from "react";
+import "./App.css";
+import MapView from "./MapView";
+import AddRestaurantForm from "./AddRestaurantForm";
+import LoadingScreen from "./LoadingScreen";
+import mapData from "./mapData.json";
 
 function App() {
-  const [tab, setTab] = useState('home');
+  const [tab, setTab] = useState("home");
   const [loading, setLoading] = useState(true);
   const prefersDark =
-    window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
   const [darkMode, setDarkMode] = useState(prefersDark);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [data, setData] = useState(() => {
-    const stored = localStorage.getItem('mapData');
+    const stored = localStorage.getItem("mapData");
     return stored ? JSON.parse(stored) : mapData;
   });
 
@@ -22,15 +24,18 @@ function App() {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('mapData', JSON.stringify(data));
+    localStorage.setItem("mapData", JSON.stringify(data));
   }, [data]);
 
   useEffect(() => {
-    document.body.dataset.theme = darkMode ? 'dark' : 'light';
+    document.body.dataset.theme = darkMode ? "dark" : "light";
   }, [darkMode]);
 
   const handleAdd = (item) => {
-    setData([...data, { ...item, notes: '', visited: false, rating: null, category: '' }]);
+    setData([
+      ...data,
+      { ...item, notes: "", visited: false, rating: null, category: "" },
+    ]);
   };
 
   return (
@@ -38,37 +43,60 @@ function App() {
       {loading && <LoadingScreen />}
       <nav className="Tabs">
         <button
-          className={tab === 'home' ? 'active' : ''}
-          onClick={() => setTab('home')}
+          className="hamburger"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Menu"
         >
-          Home
+          ☰
         </button>
-        <button
-          className={tab === 'map' ? 'active' : ''}
-          onClick={() => setTab('map')}
-        >
-          Map
-        </button>
-        <button
-          className="toggle"
-          onClick={() => setDarkMode(!darkMode)}
-        >
-          {darkMode ? 'Light' : 'Dark'}
-        </button>
+        <div className={`Menu${menuOpen ? " open" : ""}`}>
+          <button
+            className={tab === "home" ? "active" : ""}
+            onClick={() => {
+              setTab("home");
+              setMenuOpen(false);
+            }}
+          >
+            <span className="icon" role="img" aria-label="Home">
+              🏠
+            </span>
+            <span className="label">Home</span>
+          </button>
+          <button
+            className={tab === "map" ? "active" : ""}
+            onClick={() => {
+              setTab("map");
+              setMenuOpen(false);
+            }}
+          >
+            <span className="icon" role="img" aria-label="Map">
+              🗺️
+            </span>
+            <span className="label">Map</span>
+          </button>
+          <button className="toggle" onClick={() => setDarkMode(!darkMode)}>
+            <span className="icon" role="img" aria-label="Theme">
+              {darkMode ? "☀️" : "🌙"}
+            </span>
+            <span className="label">{darkMode ? "Light" : "Dark"}</span>
+          </button>
+        </div>
       </nav>
-      {tab === 'home' && (
+      {tab === "home" && (
         <div className="Form-wrapper">
           <AddRestaurantForm onAdd={handleAdd} />
         </div>
       )}
-      {tab === 'map' && (
+      {tab === "map" && (
         <div className="Map-wrapper">
           <MapView
             data={data}
             darkMode={darkMode}
             onUpdate={(idx, updates) =>
               setData((d) =>
-                d.map((item, i) => (i === idx ? { ...item, ...updates } : item))
+                d.map((item, i) =>
+                  i === idx ? { ...item, ...updates } : item,
+                ),
               )
             }
           />


### PR DESCRIPTION
## Summary
- implement hamburger button to toggle navigation
- show bottom nav icons on small screens
- style side menu for large screens

## Testing
- `npm test --silent -- -u`


------
https://chatgpt.com/codex/tasks/task_e_6840737f173c83249214e85bc4a11dd9