### PR TITLE
Add geolocation and nearby restaurants

### DIFF
--- a/src/AddRestaurantForm.js
+++ b/src/AddRestaurantForm.js
@@ -4,14 +4,12 @@ import { geocodeAddress } from './geocode';
 function AddRestaurantForm({ onAdd }) {
   const [name, setName] = useState('');
   const [address, setAddress] = useState('');
-  const [latitude, setLatitude] = useState('');
-  const [longitude, setLongitude] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    let lat = latitude ? parseFloat(latitude) : null;
-    let lon = longitude ? parseFloat(longitude) : null;
-    if (lat === null && lon === null && address) {
+    let lat = null;
+    let lon = null;
+    if (address) {
       try {
         const result = await geocodeAddress(address);
         if (result) {
@@ -30,8 +28,6 @@ function AddRestaurantForm({ onAdd }) {
     });
     setName('');
     setAddress('');
-    setLatitude('');
-    setLongitude('');
   };
 
   return (
@@ -48,20 +44,6 @@ function AddRestaurantForm({ onAdd }) {
         placeholder="Address"
         value={address}
         onChange={(e) => setAddress(e.target.value)}
-      />
-      <input
-        type="number"
-        step="any"
-        placeholder="Latitude"
-        value={latitude}
-        onChange={(e) => setLatitude(e.target.value)}
-      />
-      <input
-        type="number"
-        step="any"
-        placeholder="Longitude"
-        value={longitude}
-        onChange={(e) => setLongitude(e.target.value)}
       />
       <button type="submit">Add</button>
     </form>

--- a/src/App.js
+++ b/src/App.js
@@ -83,7 +83,7 @@ function App() {
           </button>
         </div>
       </nav>
-      {tab === 'home' && <HomeScreen onAdd={handleAdd} />}
+      {tab === 'home' && <HomeScreen onAdd={handleAdd} data={data} />}
       {tab === 'map' && (
         <div className="Map-wrapper">
           <MapView

--- a/src/HomeScreen.css
+++ b/src/HomeScreen.css
@@ -3,18 +3,6 @@
   padding: 1rem;
 }
 
-.Carousel {
-  max-width: 800px;
-  margin: 0 auto;
-  overflow: hidden;
-  border-radius: 0.5rem;
-}
-
-.Carousel img {
-  width: 100%;
-  display: block;
-  border-radius: 0.5rem;
-}
 
 .Intro {
   margin: 1rem auto;
@@ -29,4 +17,37 @@
   border: 1px solid var(--hover-bg);
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.NearestSection {
+  margin: 1rem auto;
+  max-width: 800px;
+  text-align: left;
+}
+
+.NearestList {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding: 0.5rem 0;
+}
+
+.RestaurantCard {
+  flex: 0 0 auto;
+  background: var(--header-bg);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  min-width: 150px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.RestaurantCard .title {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.RestaurantCard .distance {
+  font-size: 0.8rem;
+  opacity: 0.8;
 }

--- a/src/HomeScreen.js
+++ b/src/HomeScreen.js
@@ -1,30 +1,43 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import AddRestaurantForm from './AddRestaurantForm';
 import './HomeScreen.css';
 
-function HomeScreen({ onAdd }) {
-  const images = [
-    'https://loremflickr.com/800/400/pizza?lock=1',
-    'https://loremflickr.com/800/400/burger?lock=2',
-    'https://loremflickr.com/800/400/sushi?lock=3',
-    'https://loremflickr.com/800/400/dessert?lock=4',
-    'https://loremflickr.com/800/400/pasta?lock=5',
-  ];
-  const [index, setIndex] = useState(0);
+function haversine(lat1, lon1, lat2, lon2) {
+  const R = 6371; // km
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function HomeScreen({ onAdd, data }) {
+  const [location, setLocation] = useState(null);
 
   useEffect(() => {
-    const id = setInterval(
-      () => setIndex((i) => (i + 1) % images.length),
-      3000
-    );
-    return () => clearInterval(id);
-  }, [images.length]);
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition((pos) => {
+      setLocation({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+    });
+  }, []);
+
+  const nearest = useMemo(() => {
+    if (!location) return [];
+    return data
+      .filter((d) => d.latitude !== null && d.longitude !== null)
+      .map((d) => ({
+        ...d,
+        distance: haversine(location.lat, location.lon, d.latitude, d.longitude),
+      }))
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 5);
+  }, [location, data]);
 
   return (
     <div className="Home">
-      <div className="Carousel">
-        <img src={images[index]} alt="Delicious food" />
-      </div>
       <div className="Intro">
         <h1>Restaurant Explorer</h1>
         <p>
@@ -36,6 +49,20 @@ function HomeScreen({ onAdd }) {
         <h2>Add a Restaurant</h2>
         <AddRestaurantForm onAdd={onAdd} />
       </div>
+      {nearest.length > 0 && (
+        <div className="NearestSection">
+          <h2>Nearby Restaurants</h2>
+          <div className="NearestList">
+            {nearest.map((r, idx) => (
+              <div key={idx} className="RestaurantCard">
+                <div className="title">{r.name}</div>
+                {r.address && <div className="address">{r.address}</div>}
+                <div className="distance">{r.distance.toFixed(1)} km</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop latitude/longitude fields from the add form
- use geocoding service to obtain coordinates when adding restaurants
- remove the image carousel from the home screen
- show a horizontal list of restaurants closest to the user
- adjust styling for the new layout

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b6a7472483248c81a9a7ed8d717d