### PR TITLE
Adjust mobile nav position

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -203,12 +203,12 @@
 
 @media (max-width: 600px) {
   body {
-    padding-bottom: var(--nav-height);
+    padding-bottom: calc(var(--nav-height) + var(--bottom-offset));
   }
 
   .Tabs {
     position: fixed;
-    bottom: 0;
+    bottom: var(--bottom-offset);
     left: 0;
     right: 0;
     border-top: 1px solid var(--hover-bg);

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,7 @@
   --modal-overlay-bg: rgba(0, 0, 0, 0.5);
   --accent-color: #4f46e5;
   --nav-height: 3rem;
+  --bottom-offset: 1rem;
 }
 
 [data-theme='dark'] {


### PR DESCRIPTION
## Summary
- add `--bottom-offset` CSS variable
- lift bottom nav using the new variable so it is easier to reach on iPhone

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841d1e8ef0c8324af797916efb2ebcd