### PR TITLE
Add Explore and Profile pages with updated bottom nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "leaflet": "^1.9.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-icons": "^4.12.0",
         "react-leaflet": "^4.2.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -15716,6 +15717,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "leaflet": "^1.9.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-icons": "^4.12.0",
     "react-leaflet": "^4.2.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
+import { MdHome, MdExplore, MdMap, MdPerson, MdDarkMode, MdLightMode, MdMenu } from 'react-icons/md';
 import './App.css';
 import MapView from './MapView';
 import HomeScreen from './HomeScreen';
+import ExploreScreen from './ExploreScreen';
+import ProfileScreen from './ProfileScreen';
 import LoadingScreen from './LoadingScreen';
 import mapData from './mapData.json';
 
@@ -48,7 +51,7 @@ function App() {
           onClick={() => setMenuOpen(!menuOpen)}
           aria-label="Menu"
         >
-          ☰
+          <MdMenu />
         </button>
         <div className={`Menu${menuOpen ? " open" : ""}`}>
           <button
@@ -58,10 +61,22 @@ function App() {
               setMenuOpen(false);
             }}
           >
-            <span className="icon" role="img" aria-label="Home">
-              🏠
+            <span className="icon" aria-label="Home">
+              <MdHome />
             </span>
             <span className="label">Home</span>
+          </button>
+          <button
+            className={tab === "explore" ? "active" : ""}
+            onClick={() => {
+              setTab("explore");
+              setMenuOpen(false);
+            }}
+          >
+            <span className="icon" aria-label="Explore">
+              <MdExplore />
+            </span>
+            <span className="label">Explore</span>
           </button>
           <button
             className={tab === "map" ? "active" : ""}
@@ -70,20 +85,33 @@ function App() {
               setMenuOpen(false);
             }}
           >
-            <span className="icon" role="img" aria-label="Map">
-              🗺️
+            <span className="icon" aria-label="Map">
+              <MdMap />
             </span>
             <span className="label">Map</span>
           </button>
+          <button
+            className={tab === "profile" ? "active" : ""}
+            onClick={() => {
+              setTab("profile");
+              setMenuOpen(false);
+            }}
+          >
+            <span className="icon" aria-label="Profile">
+              <MdPerson />
+            </span>
+            <span className="label">Profile</span>
+          </button>
           <button className="toggle" onClick={() => setDarkMode(!darkMode)}>
-            <span className="icon" role="img" aria-label="Theme">
-              {darkMode ? "☀️" : "🌙"}
+            <span className="icon" aria-label="Theme">
+              {darkMode ? <MdLightMode /> : <MdDarkMode />}
             </span>
             <span className="label">{darkMode ? "Light" : "Dark"}</span>
           </button>
         </div>
       </nav>
       {tab === 'home' && <HomeScreen onAdd={handleAdd} data={data} />}
+      {tab === 'explore' && <ExploreScreen data={data} />}
       {tab === 'map' && (
         <div className="Map-wrapper">
           <MapView
@@ -99,6 +127,7 @@ function App() {
           />
         </div>
       )}
+      {tab === 'profile' && <ProfileScreen />}
     </div>
   );
 }

--- a/src/ExploreScreen.css
+++ b/src/ExploreScreen.css
@@ -1,0 +1,31 @@
+.Explore {
+  text-align: center;
+  padding: 1rem;
+}
+
+.CategoryGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.CatCard {
+  background: var(--header-bg);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  min-width: 120px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.CatCard .cat-name {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.CatCard .cat-count {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}

--- a/src/ExploreScreen.js
+++ b/src/ExploreScreen.js
@@ -1,0 +1,26 @@
+import './ExploreScreen.css';
+
+function ExploreScreen({ data }) {
+  const categories = Array.from(new Set(data.map(d => d.category).filter(Boolean)));
+  const counts = categories.map(cat => ({
+    cat,
+    count: data.filter(d => d.category === cat).length,
+  }));
+
+  return (
+    <div className="Explore">
+      <h1>Explore</h1>
+      <p>Browse restaurants by category:</p>
+      <div className="CategoryGrid">
+        {counts.map(({ cat, count }) => (
+          <div key={cat} className="CatCard">
+            <div className="cat-name">{cat.charAt(0).toUpperCase() + cat.slice(1)}</div>
+            <div className="cat-count">{count} places</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ExploreScreen;

--- a/src/ProfileScreen.css
+++ b/src/ProfileScreen.css
@@ -1,0 +1,30 @@
+.Profile {
+  text-align: center;
+  padding: 1rem;
+}
+
+.ProfileCard {
+  max-width: 300px;
+  margin: 1rem auto;
+  background: var(--header-bg);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.ProfileCard .avatar {
+  font-size: 2rem;
+}
+
+.ProfileCard .info .name {
+  font-weight: bold;
+}
+
+.ProfileCard .info .email {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}

--- a/src/ProfileScreen.js
+++ b/src/ProfileScreen.js
@@ -1,0 +1,19 @@
+import './ProfileScreen.css';
+
+function ProfileScreen() {
+  return (
+    <div className="Profile">
+      <h1>Your Profile</h1>
+      <p>This is a placeholder profile page.</p>
+      <div className="ProfileCard">
+        <div className="avatar">🙂</div>
+        <div className="info">
+          <div className="name">Jane Doe</div>
+          <div className="email">jane@example.com</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProfileScreen;

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
   --modal-overlay-bg: rgba(0, 0, 0, 0.5);
   --accent-color: #4f46e5;
   --nav-height: 3rem;
-  --bottom-offset: 1rem;
+  --bottom-offset: 2rem;
 }
 
 [data-theme='dark'] {


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- create ExploreScreen and ProfileScreen
- update bottom nav icons and add Explore/Profile tabs
- increase bottom offset for footer spacing

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68424b0254488324a15206a79811b59d