### PR TITLE
Add slide-down filter panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,27 @@
   color: var(--active-tab-color);
 }
 
+.FilterPanel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.FilterPanel.show {
+  max-height: 100px;
+}
+
+.filter-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
 .CategoryRow {
   display: flex;
   overflow-x: auto;

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -21,6 +21,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
   const [modalIndex, setModalIndex] = useState(null);
   const [search, setSearch] = useState("");
   const [activeCat, setActiveCat] = useState(null);
+  const [showFilters, setShowFilters] = useState(false);
+  const [visitedFilter, setVisitedFilter] = useState("all");
+  const [sortBy, setSortBy] = useState("name");
 
   const categoryEmojis = {
     bagel: "🥯",
@@ -94,7 +97,22 @@ function MapView({ data, onUpdate, darkMode = false }) {
         item.name.toLowerCase().includes(term) ||
         (item.address && item.address.toLowerCase().includes(term));
       const matchesCat = !activeCat || item.category === activeCat;
-      return matchesTerm && matchesCat;
+      const matchesVisited =
+        visitedFilter === "all" ||
+        (visitedFilter === "visited" && item.visited) ||
+        (visitedFilter === "unvisited" && !item.visited);
+      return matchesTerm && matchesCat && matchesVisited;
+    })
+    .sort((a, b) => {
+      if (sortBy === "name") {
+        return a.item.name.localeCompare(b.item.name);
+      }
+      if (sortBy === "rating") {
+        const ra = a.item.rating ?? -Infinity;
+        const rb = b.item.rating ?? -Infinity;
+        return rb - ra;
+      }
+      return 0;
     });
 
   const center =
@@ -123,12 +141,45 @@ function MapView({ data, onUpdate, darkMode = false }) {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <button className="filter-btn" aria-label="Filters">
+          <button
+            className="filter-btn"
+            aria-label="Filters"
+            aria-expanded={showFilters}
+            onClick={() => setShowFilters(!showFilters)}
+          >
             <span role="img" aria-label="Filter">
               ⚙️
             </span>
           </button>
         </div>
+        <div className={`FilterPanel${showFilters ? ' show' : ''}`}>
+          <div className="filter-group">
+            <label>
+              Visited
+              <select
+                value={visitedFilter}
+                onChange={(e) => setVisitedFilter(e.target.value)}
+              >
+                <option value="all">All</option>
+                <option value="visited">Visited</option>
+                <option value="unvisited">Unvisited</option>
+              </select>
+            </label>
+          </div>
+          <div className="filter-group">
+            <label>
+              Sort by
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value)}
+              >
+                <option value="name">Name</option>
+                <option value="rating">Rating</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
         <div className="CategoryRow">
           {categories.map((c) => (
             <button


### PR DESCRIPTION
## Summary
- toggle a filter panel in MapView
- support filtering by visited status and sorting by name or rating
- keep categories outside the filter panel

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68424cc44ef883248229b2e6ed5b5ba5