### PR TITLE
Move theme toggle to Profile screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -88,11 +88,6 @@
   color: var(--text-color);
 }
 
-.Tabs button.toggle {
-  flex: 0;
-  padding: 0 1rem;
-  border-radius: 0;
-}
 
 .Tabs button.active {
   background: var(--active-tab-bg);
@@ -185,6 +180,27 @@
 .SearchBar .filter-btn:hover {
   background: var(--active-tab-bg);
   color: var(--active-tab-color);
+}
+
+.FilterPanel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.FilterPanel.show {
+  max-height: 100px;
+}
+
+.filter-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
 }
 
 .CategoryRow {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { MdHome, MdExplore, MdMap, MdPerson, MdDarkMode, MdLightMode, MdMenu } from 'react-icons/md';
+import { MdHome, MdExplore, MdMap, MdPerson, MdMenu } from 'react-icons/md';
 import './App.css';
 import MapView from './MapView';
 import HomeScreen from './HomeScreen';
@@ -102,12 +102,6 @@ function App() {
             </span>
             <span className="label">Profile</span>
           </button>
-          <button className="toggle" onClick={() => setDarkMode(!darkMode)}>
-            <span className="icon" aria-label="Theme">
-              {darkMode ? <MdLightMode /> : <MdDarkMode />}
-            </span>
-            <span className="label">{darkMode ? "Light" : "Dark"}</span>
-          </button>
         </div>
       </nav>
       {tab === 'home' && <HomeScreen onAdd={handleAdd} data={data} />}
@@ -127,7 +121,9 @@ function App() {
           />
         </div>
       )}
-      {tab === 'profile' && <ProfileScreen />}
+      {tab === 'profile' && (
+        <ProfileScreen darkMode={darkMode} setDarkMode={setDarkMode} />
+      )}
     </div>
   );
 }

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -21,6 +21,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
   const [modalIndex, setModalIndex] = useState(null);
   const [search, setSearch] = useState("");
   const [activeCat, setActiveCat] = useState(null);
+  const [showFilters, setShowFilters] = useState(false);
+  const [visitedFilter, setVisitedFilter] = useState("all");
+  const [sortBy, setSortBy] = useState("name");
 
   const categoryEmojis = {
     bagel: "🥯",
@@ -94,7 +97,22 @@ function MapView({ data, onUpdate, darkMode = false }) {
         item.name.toLowerCase().includes(term) ||
         (item.address && item.address.toLowerCase().includes(term));
       const matchesCat = !activeCat || item.category === activeCat;
-      return matchesTerm && matchesCat;
+      const matchesVisited =
+        visitedFilter === "all" ||
+        (visitedFilter === "visited" && item.visited) ||
+        (visitedFilter === "unvisited" && !item.visited);
+      return matchesTerm && matchesCat && matchesVisited;
+    })
+    .sort((a, b) => {
+      if (sortBy === "name") {
+        return a.item.name.localeCompare(b.item.name);
+      }
+      if (sortBy === "rating") {
+        const ra = a.item.rating ?? -Infinity;
+        const rb = b.item.rating ?? -Infinity;
+        return rb - ra;
+      }
+      return 0;
     });
 
   const center =
@@ -123,12 +141,45 @@ function MapView({ data, onUpdate, darkMode = false }) {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <button className="filter-btn" aria-label="Filters">
+          <button
+            className="filter-btn"
+            aria-label="Filters"
+            aria-expanded={showFilters}
+            onClick={() => setShowFilters(!showFilters)}
+          >
             <span role="img" aria-label="Filter">
               ⚙️
             </span>
           </button>
         </div>
+        <div className={`FilterPanel${showFilters ? ' show' : ''}`}>
+          <div className="filter-group">
+            <label>
+              Visited
+              <select
+                value={visitedFilter}
+                onChange={(e) => setVisitedFilter(e.target.value)}
+              >
+                <option value="all">All</option>
+                <option value="visited">Visited</option>
+                <option value="unvisited">Unvisited</option>
+              </select>
+            </label>
+          </div>
+          <div className="filter-group">
+            <label>
+              Sort by
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value)}
+              >
+                <option value="name">Name</option>
+                <option value="rating">Rating</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
         <div className="CategoryRow">
           {categories.map((c) => (
             <button

--- a/src/ProfileScreen.css
+++ b/src/ProfileScreen.css
@@ -28,3 +28,16 @@
   font-size: 0.9rem;
   opacity: 0.8;
 }
+
+.theme-toggle {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--button-bg);
+  color: var(--button-text);
+  border: none;
+  border-radius: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}

--- a/src/ProfileScreen.js
+++ b/src/ProfileScreen.js
@@ -1,6 +1,7 @@
 import './ProfileScreen.css';
+import { MdDarkMode, MdLightMode } from 'react-icons/md';
 
-function ProfileScreen() {
+function ProfileScreen({ darkMode, setDarkMode }) {
   return (
     <div className="Profile">
       <h1>Your Profile</h1>
@@ -12,6 +13,15 @@ function ProfileScreen() {
           <div className="email">jane@example.com</div>
         </div>
       </div>
+      <button
+        className="theme-toggle"
+        onClick={() => setDarkMode(!darkMode)}
+      >
+        <span className="icon" aria-label="Theme">
+          {darkMode ? <MdLightMode /> : <MdDarkMode />}
+        </span>
+        <span className="label">{darkMode ? 'Light' : 'Dark'}</span>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- relocate theme toggle from the navigation menu to the Profile screen
- add slide-down filter panel with visited and sort options
- keep category buttons visible outside the filter panel
- remove unused icon imports from `App.js`

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68424cc44ef883248229b2e6ed5b5ba5