### PR TITLE
Add slide down filter sorting

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,32 @@
   color: var(--active-tab-color);
 }
 
+.Filters {
+  overflow: hidden;
+  max-height: 250px;
+  transition: max-height 0.3s ease;
+}
+
+.Filters.collapsed {
+  max-height: 0;
+}
+
+.Filters .SortRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.Filters .SortRow select {
+  flex: 1;
+  padding: 0.25rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.25rem;
+}
+
 .CategoryRow {
   display: flex;
   overflow-x: auto;
@@ -246,6 +272,11 @@
 }
 
 .card-info .address {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.card-info .distance {
   font-size: 0.8rem;
   opacity: 0.8;
 }


### PR DESCRIPTION
## Summary
- add sorting logic and location handling to `MapView`
- implement slide-down Filters panel with sort options
- display distance info when sorted by distance
- style new filter UI and distance row

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6842789947788324b917ad60d5de82e9