### PR TITLE
Add theme toggle on profile page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { MdHome, MdExplore, MdMap, MdPerson, MdDarkMode, MdLightMode, MdMenu } from 'react-icons/md';
+import { MdHome, MdExplore, MdMap, MdPerson, MdMenu } from 'react-icons/md';
 import './App.css';
 import MapView from './MapView';
 import HomeScreen from './HomeScreen';
@@ -102,12 +102,6 @@ function App() {
             </span>
             <span className="label">Profile</span>
           </button>
-          <button className="toggle" onClick={() => setDarkMode(!darkMode)}>
-            <span className="icon" aria-label="Theme">
-              {darkMode ? <MdLightMode /> : <MdDarkMode />}
-            </span>
-            <span className="label">{darkMode ? "Light" : "Dark"}</span>
-          </button>
         </div>
       </nav>
       {tab === 'home' && <HomeScreen onAdd={handleAdd} data={data} />}
@@ -127,7 +121,9 @@ function App() {
           />
         </div>
       )}
-      {tab === 'profile' && <ProfileScreen />}
+      {tab === 'profile' && (
+        <ProfileScreen darkMode={darkMode} setDarkMode={setDarkMode} />
+      )}
     </div>
   );
 }

--- a/src/ProfileScreen.css
+++ b/src/ProfileScreen.css
@@ -28,3 +28,16 @@
   font-size: 0.9rem;
   opacity: 0.8;
 }
+
+.theme-toggle {
+  margin-top: 1rem;
+  background: var(--button-bg);
+  color: var(--button-text);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}

--- a/src/ProfileScreen.js
+++ b/src/ProfileScreen.js
@@ -1,6 +1,7 @@
+import { MdDarkMode, MdLightMode } from 'react-icons/md';
 import './ProfileScreen.css';
 
-function ProfileScreen() {
+function ProfileScreen({ darkMode, setDarkMode }) {
   return (
     <div className="Profile">
       <h1>Your Profile</h1>
@@ -12,6 +13,14 @@ function ProfileScreen() {
           <div className="email">jane@example.com</div>
         </div>
       </div>
+      <button
+        className="theme-toggle"
+        onClick={() => setDarkMode(!darkMode)}
+        aria-label="Toggle Theme"
+      >
+        {darkMode ? <MdLightMode /> : <MdDarkMode />}
+        <span className="label">{darkMode ? 'Light' : 'Dark'} Mode</span>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove navigation bar theme toggle
- move dark/light mode toggle to Profile screen

## Testing
- `npm install --silent`
- `npm test --silent --runTestsByPath src/App.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6842e3c195d88324aad3ebbbd9574bb4