### PR TITLE
Move categories list and update filters

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -171,8 +171,8 @@
 }
 
 .SearchBar .filter-btn {
-  width: 2rem;
-  height: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
   background: var(--hover-bg);
   border: none;
   border-radius: 50%;

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect, useMemo } from "react";
 import { MapContainer, TileLayer, Marker, Popup, Circle } from "react-leaflet";
+import { MdFilterList } from "react-icons/md";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import DetailModal from "./DetailModal";
@@ -189,10 +190,19 @@ function MapView({ data, onUpdate, darkMode = false }) {
             aria-expanded={showFilters}
             onClick={() => setShowFilters(!showFilters)}
           >
-            <span role="img" aria-label="Filter">
-              ⚙️
-            </span>
+            <MdFilterList size={24} />
           </button>
+        </div>
+        <div className="CategoryRow">
+          {categories.map((c) => (
+            <button
+              key={c}
+              className={c === activeCat ? "active" : ""}
+              onClick={() => setActiveCat(c === activeCat ? null : c)}
+            >
+              {catLabel(c)}
+            </button>
+          ))}
         </div>
         <div className={`Filters${showFilters ? '' : ' collapsed'}`}>
           <div className="SortRow">
@@ -206,17 +216,6 @@ function MapView({ data, onUpdate, darkMode = false }) {
               <option value="alphabetical">Alphabetical</option>
               <option value="distance">Distance</option>
             </select>
-          </div>
-          <div className="CategoryRow">
-            {categories.map((c) => (
-              <button
-                key={c}
-                className={c === activeCat ? "active" : ""}
-                onClick={() => setActiveCat(c === activeCat ? null : c)}
-              >
-                {catLabel(c)}
-              </button>
-            ))}
           </div>
         </div>
         {filteredItems.map(({ item, idx, distance }) => (


### PR DESCRIPTION
## Summary
- always show category pills instead of hiding them in Filters
- use a filter icon and bump button size

## Testing
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68435bd2371c8324bbaa8ac4e7650efd