### PR TITLE
Add recent and visited options to sort

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -213,21 +213,6 @@
   border-radius: 0.25rem;
 }
 
-.Filters .VisitedRow {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 0.25rem 0 0.5rem;
-}
-
-.Filters .VisitedRow select {
-  flex: 1;
-  padding: 0.25rem;
-  background: var(--bg-color);
-  color: var(--text-color);
-  border: 1px solid var(--hover-bg);
-  border-radius: 0.25rem;
-}
 
 .CategoryRow {
   display: flex;

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -23,8 +23,7 @@ function MapView({ data, onUpdate, darkMode = false }) {
   const [search, setSearch] = useState("");
   const [activeCat, setActiveCat] = useState(null);
   const [showFilters, setShowFilters] = useState(false);
-  const [sort, setSort] = useState("default");
-  const [visitedFilter, setVisitedFilter] = useState("all");
+  const [sort, setSort] = useState("recent");
   const [location, setLocation] = useState(null);
 
   const categoryEmojis = {
@@ -120,9 +119,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
         (item.address && item.address.toLowerCase().includes(term));
       const matchesCat = !activeCat || item.category === activeCat;
       const matchesVisited =
-        visitedFilter === "all" ||
-        (visitedFilter === "visited" && item.visited) ||
-        (visitedFilter === "unvisited" && !item.visited);
+        (sort !== "visited" && sort !== "unvisited") ||
+        (sort === "visited" && item.visited) ||
+        (sort === "unvisited" && !item.visited);
       return matchesTerm && matchesCat && matchesVisited;
     })
     .map(({ item, idx }) => {
@@ -150,6 +149,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
         if (a.distance === null) return 1;
         if (b.distance === null) return -1;
         return a.distance - b.distance;
+      }
+      if (sort === "recent") {
+        return b.idx - a.idx;
       }
       return 0;
     });
@@ -217,19 +219,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
               value={sort}
               onChange={(e) => setSort(e.target.value)}
             >
-              <option value="default">None</option>
+              <option value="recent">Most Recently Added</option>
               <option value="alphabetical">Alphabetical</option>
               <option value="distance">Distance</option>
-            </select>
-          </div>
-          <div className="VisitedRow">
-            <label htmlFor="visited-select">Visited:</label>
-            <select
-              id="visited-select"
-              value={visitedFilter}
-              onChange={(e) => setVisitedFilter(e.target.value)}
-            >
-              <option value="all">All</option>
               <option value="visited">Visited</option>
               <option value="unvisited">Not Visited</option>
             </select>


### PR DESCRIPTION
## Summary
- combine visited filter into the sort dropdown
- add "Most Recently Added" sort option and set it as default
- remove unused visited filter styles

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68437cbb1cf0832481a21925ff5a1c6d