### PR TITLE
Fix mobile map overlap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,7 +100,7 @@
 }
 
 .Map-wrapper {
-  height: calc(100vh - var(--nav-height));
+  height: calc(100vh - var(--nav-height) - var(--bottom-offset));
   min-height: 350px;
 }
 
@@ -322,7 +322,7 @@
   }
 
   .Map-wrapper {
-    height: calc(100vh - var(--nav-height));
+    height: calc(100vh - var(--nav-height) - var(--bottom-offset));
     min-height: 300px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
   --modal-overlay-bg: rgba(0, 0, 0, 0.5);
   --accent-color: #4f46e5;
   --nav-height: 3rem;
-  --bottom-offset: 2rem;
+  --bottom-offset: env(safe-area-inset-bottom, 0px);
 }
 
 [data-theme='dark'] {


### PR DESCRIPTION
## Summary
- account for iOS safe area inset
- adjust mobile map height so it doesn't scroll under the bottom nav

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6843830e7ed4832483106c58bd99455b