### PR TITLE
Make arrow open edit modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -286,6 +286,15 @@
   font-size: 1.25rem;
 }
 
+.arrow-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
 .Map-area {
   flex: 1;
   height: 100%;

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -177,8 +177,6 @@ function MapView({ data, onUpdate, darkMode = false }) {
         ref.openPopup();
       }
     }
-    // Open the detail modal just like clicking on the marker
-    setModalIndex(idx);
   };
 
   return (
@@ -243,7 +241,16 @@ function MapView({ data, onUpdate, darkMode = false }) {
                 <div className="distance">{distance.toFixed(1)} km</div>
               )}
             </div>
-            <span className="arrow">{"\u27A4"}</span>
+            <button
+              className="arrow-btn"
+              aria-label="Edit"
+              onClick={(e) => {
+                e.stopPropagation();
+                setModalIndex(idx);
+              }}
+            >
+              <span className="arrow">{"\u27A4"}</span>
+            </button>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- make restaurant list arrow a button for editing
- clicking a card now only zooms to the marker

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843952c41e08324aa97063f01eb3a9d