### PR TITLE
Add rating and notes support

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -277,6 +277,11 @@
   opacity: 0.8;
 }
 
+.card-info .rating {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
 .card-info .distance {
   font-size: 0.8rem;
   opacity: 0.8;

--- a/src/DetailModal.css
+++ b/src/DetailModal.css
@@ -35,6 +35,16 @@
   border-radius: 0.25rem;
 }
 
+.Modal input[type='number'],
+.Modal textarea {
+  width: 100%;
+  margin-top: 0.25rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--hover-bg);
+  border-radius: 0.25rem;
+}
+
 .Modal .actions {
   margin-top: 1rem;
   text-align: right;

--- a/src/DetailModal.js
+++ b/src/DetailModal.js
@@ -5,9 +5,17 @@ function DetailModal({ item, onClose, onSave }) {
   const [name, setName] = useState(item.name);
   const [address, setAddress] = useState(item.address || '');
   const [visited, setVisited] = useState(item.visited || false);
+  const [rating, setRating] = useState(item.rating || '');
+  const [notes, setNotes] = useState(item.notes || '');
 
   const handleSave = () => {
-    onSave({ name, address, visited });
+    onSave({
+      name,
+      address,
+      visited,
+      rating: rating === '' ? null : Math.min(5, Math.max(1, Number(rating))),
+      notes,
+    });
   };
 
   return (
@@ -29,6 +37,23 @@ function DetailModal({ item, onClose, onSave }) {
             onChange={(e) => setVisited(e.target.checked)}
           />
           Visited
+        </label>
+        <label>
+          Rating (1-5)
+          <input
+            type="number"
+            min="1"
+            max="5"
+            value={rating}
+            onChange={(e) => setRating(e.target.value)}
+          />
+        </label>
+        <label>
+          Notes
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          ></textarea>
         </label>
         <div className="actions">
           <button onClick={handleSave}>Save</button>

--- a/src/MapView.js
+++ b/src/MapView.js
@@ -237,6 +237,9 @@ function MapView({ data, onUpdate, darkMode = false }) {
                 {item.name}
               </div>
               {item.address && <div className="address">{item.address}</div>}
+              {item.visited && item.rating != null && (
+                <div className="rating">{item.rating}/5</div>
+              )}
               {sort === "distance" && distance !== null && (
                 <div className="distance">{distance.toFixed(1)} km</div>
               )}


### PR DESCRIPTION
## Summary
- allow editing rating and notes in restaurant detail modal
- display rating on restaurant cards if visited
- style rating text and modal inputs

## Testing
- `npm test --silent -- --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6843a37b51dc83248610ad251143acbe